### PR TITLE
refactor(UIKIT-750): Упрощены ошибки валидаций и их создание

### DIFF
--- a/package/src/array/array.test.ts
+++ b/package/src/array/array.test.ts
@@ -7,7 +7,7 @@ describe('array', () => {
     (value) => {
       const error = array()(value);
 
-      expect(error?.cause.code).toBe(ARRAY_TYPE_ERROR_INFO.code);
+      expect(error?.code).toBe(ARRAY_TYPE_ERROR_INFO.code);
     },
   );
 

--- a/package/src/array/array.ts
+++ b/package/src/array/array.ts
@@ -25,10 +25,10 @@ export const array = <TItem extends ValidationTypes, TValues = unknown>(
 ) =>
   createGuard<Array<unknown>, TValues>((value, ctx, { typeErrorMessage }) => {
     if (!Array.isArray(value)) {
-      return {
+      return ctx.createError({
         ...ARRAY_TYPE_ERROR_INFO,
         message: typeErrorMessage || ARRAY_TYPE_ERROR_INFO.message,
-      };
+      });
     }
 
     return compose<Array<TItem>, TValues>(...rules)(value, ctx);

--- a/package/src/array/array.ts
+++ b/package/src/array/array.ts
@@ -25,10 +25,10 @@ export const array = <TItem extends ValidationTypes, TValues = unknown>(
 ) =>
   createGuard<Array<unknown>, TValues>((value, ctx, { typeErrorMessage }) => {
     if (!Array.isArray(value)) {
-      return ctx.createError({
+      return {
         ...ARRAY_TYPE_ERROR_INFO,
         message: typeErrorMessage || ARRAY_TYPE_ERROR_INFO.message,
-      });
+      };
     }
 
     return compose<Array<TItem>, TValues>(...rules)(value, ctx);

--- a/package/src/array/constants.ts
+++ b/package/src/array/constants.ts
@@ -1,6 +1,6 @@
-import { ErrorInfo } from '../core';
+import { ErrorInfo, createErrorCode } from '../core';
 
 export const ARRAY_TYPE_ERROR_INFO: ErrorInfo = {
-  code: Symbol('array'),
+  code: createErrorCode('array'),
   message: 'Не является массивом',
 };

--- a/package/src/arrayItem/arrayItem.test.ts
+++ b/package/src/arrayItem/arrayItem.test.ts
@@ -12,9 +12,9 @@ describe('arrayItem', () => {
     const errorCode = createErrorCode('error');
 
     const validateArray = array(
-      arrayItem<string | number>((value, ctx) => {
+      arrayItem<string | number>((value) => {
         if (typeof value === 'number') {
-          return ctx.createError({ message: 'number error', code: errorCode });
+          return { message: 'number error', code: errorCode };
         }
 
         return undefined;

--- a/package/src/arrayItem/arrayItem.test.ts
+++ b/package/src/arrayItem/arrayItem.test.ts
@@ -12,9 +12,9 @@ describe('arrayItem', () => {
     const errorCode = createErrorCode('error');
 
     const validateArray = array(
-      arrayItem<string | number>((value) => {
+      arrayItem<string | number>((value, ctx) => {
         if (typeof value === 'number') {
-          return { message: 'number error', code: errorCode };
+          return ctx.createError({ message: 'number error', code: errorCode });
         }
 
         return undefined;

--- a/package/src/arrayItem/arrayItem.test.ts
+++ b/package/src/arrayItem/arrayItem.test.ts
@@ -1,11 +1,15 @@
-import { ValidationArrayError, createSimpleError } from '../core';
+import {
+  ValidationArrayError,
+  createErrorCode,
+  createSimpleError,
+} from '../core';
 import { array } from '../array';
 
 import { arrayItem } from './arrayItem';
 
 describe('arrayItem', () => {
   it('Каждый элемент массива ошибок соответствует результату выполнения правила валидации для item', () => {
-    const errorCode = Symbol();
+    const errorCode = createErrorCode('error');
 
     const validateArray = array(
       arrayItem<string | number>((value, ctx) => {
@@ -25,9 +29,7 @@ describe('arrayItem', () => {
       createSimpleError({ message: 'number error', code: errorCode }),
     ];
 
-    expect((error as ValidationArrayError).cause.errorArray).toEqual(
-      expectedErrors,
-    );
+    expect((error as ValidationArrayError).errorArray).toEqual(expectedErrors);
   });
 
   it('Не возвращает ошибку, если все item валидные', () => {

--- a/package/src/core/compose/compose.test.ts
+++ b/package/src/core/compose/compose.test.ts
@@ -1,12 +1,20 @@
-import { createSimpleError } from '../errors';
+import { createErrorCode, createSimpleError } from '../errors';
 
 import { compose } from './compose';
 
 describe('compose', () => {
   it('Выполняет правила слева направо', () => {
     const validate = compose(
-      () => createSimpleError({ code: Symbol(), message: 'error1' }),
-      () => createSimpleError({ code: Symbol(), message: 'error2' }),
+      () =>
+        createSimpleError({
+          code: createErrorCode('error1'),
+          message: 'error1',
+        }),
+      () =>
+        createSimpleError({
+          code: createErrorCode('error2'),
+          message: 'error2',
+        }),
     );
 
     expect(validate(null)?.message).toBe('error1');
@@ -14,8 +22,16 @@ describe('compose', () => {
 
   it('Поддерживается вложенность', () => {
     const composed1 = compose(
-      () => createSimpleError({ code: Symbol(), message: 'error1' }),
-      () => createSimpleError({ code: Symbol(), message: 'error1' }),
+      () =>
+        createSimpleError({
+          code: createErrorCode('error1'),
+          message: 'error1',
+        }),
+      () =>
+        createSimpleError({
+          code: createErrorCode('error2'),
+          message: 'error1',
+        }),
     );
     const validate = compose(() => undefined, composed1);
 

--- a/package/src/core/context/createContext/createContext.test.ts
+++ b/package/src/core/context/createContext/createContext.test.ts
@@ -1,4 +1,4 @@
-import { ValidationSimpleError, createSimpleError } from '../../errors';
+import { createErrorCode, createSimpleError } from '../../errors';
 
 import { createContext } from './createContext';
 
@@ -33,8 +33,11 @@ describe('createContext', () => {
   it('В контексте доступна фабрика для создания SimpleError валидации', () => {
     const ctx = createContext(undefined, 'value');
 
-    const error = ctx.createError({ code: Symbol(), message: 'error' });
+    const error = ctx.createError({
+      code: createErrorCode('error'),
+      message: 'error',
+    });
 
-    expect(error instanceof ValidationSimpleError).toBeTruthy();
+    expect(error).toEqual({ code: createErrorCode('error'), message: 'error' });
   });
 });

--- a/package/src/core/context/createContext/createContext.test.ts
+++ b/package/src/core/context/createContext/createContext.test.ts
@@ -1,4 +1,4 @@
-import { createErrorCode, createSimpleError } from '../../errors';
+import { createSimpleError } from '../../errors';
 
 import { createContext } from './createContext';
 
@@ -28,16 +28,5 @@ describe('createContext', () => {
     const resultCtx = createContext(undefined, 'value');
 
     expect(resultCtx.global.values).toBe('value');
-  });
-
-  it('В контексте доступна фабрика для создания SimpleError валидации', () => {
-    const ctx = createContext(undefined, 'value');
-
-    const error = ctx.createError({
-      code: createErrorCode('error'),
-      message: 'error',
-    });
-
-    expect(error).toEqual({ code: createErrorCode('error'), message: 'error' });
   });
 });

--- a/package/src/core/context/createContext/createContext.test.ts
+++ b/package/src/core/context/createContext/createContext.test.ts
@@ -1,4 +1,4 @@
-import { createSimpleError } from '../../errors';
+import { createErrorCode, createSimpleError } from '../../errors';
 
 import { createContext } from './createContext';
 
@@ -28,5 +28,16 @@ describe('createContext', () => {
     const resultCtx = createContext(undefined, 'value');
 
     expect(resultCtx.global.values).toBe('value');
+  });
+
+  it('В контексте доступна фабрика для создания SimpleError валидации', () => {
+    const ctx = createContext(undefined, 'value');
+
+    const error = ctx.createError({
+      code: createErrorCode('error'),
+      message: 'error',
+    });
+
+    expect(error).toEqual({ code: createErrorCode('error'), message: 'error' });
   });
 });

--- a/package/src/core/context/createContext/createContext.ts
+++ b/package/src/core/context/createContext/createContext.ts
@@ -1,5 +1,4 @@
 import { ValidationContext } from '../types';
-import { createSimpleError } from '../../errors';
 import { ValidationTypes } from '../../types';
 
 /**
@@ -31,6 +30,5 @@ export function createContext<Value extends ValidationTypes, Values>(
         objectIsPartial: false,
       },
     },
-    createError: createSimpleError,
   };
 }

--- a/package/src/core/context/createContext/createContext.ts
+++ b/package/src/core/context/createContext/createContext.ts
@@ -1,4 +1,5 @@
 import { ValidationContext } from '../types';
+import { createSimpleError } from '../../errors';
 import { ValidationTypes } from '../../types';
 
 /**
@@ -30,5 +31,6 @@ export function createContext<Value extends ValidationTypes, Values>(
         objectIsPartial: false,
       },
     },
+    createError: createSimpleError,
   };
 }

--- a/package/src/core/context/types.ts
+++ b/package/src/core/context/types.ts
@@ -1,5 +1,3 @@
-import { createSimpleError } from '../errors';
-
 /**
  * @description Контекст, который доступен в каждом правиле
  */
@@ -22,8 +20,4 @@ export type ValidationContext<TValues> = Readonly<{
       objectIsPartial: boolean;
     }>;
   }>;
-  /**
-   * @description Фабрика ошибок. Возвращает новую ошибку валидации
-   */
-  createError: typeof createSimpleError;
 }>;

--- a/package/src/core/context/types.ts
+++ b/package/src/core/context/types.ts
@@ -1,3 +1,5 @@
+import { createSimpleError } from '../errors';
+
 /**
  * @description Контекст, который доступен в каждом правиле
  */
@@ -20,4 +22,8 @@ export type ValidationContext<TValues> = Readonly<{
       objectIsPartial: boolean;
     }>;
   }>;
+  /**
+   * @description Фабрика ошибок. Возвращает новую ошибку валидации
+   */
+  createError: typeof createSimpleError;
 }>;

--- a/package/src/core/errors/ArrayError/ArrayError.ts
+++ b/package/src/core/errors/ArrayError/ArrayError.ts
@@ -1,26 +1,10 @@
 import { ValidationResult } from '../../types';
-import { ValidationErrorData, ValidationSimpleError } from '../SimpleError';
+import { ValidationSimpleError } from '../SimpleError';
 
-/**
- * @description Доп. поля для ошибок элементов массива
- */
-export type ValidationArrayErrorCause = {
+export type ValidationArrayError = ValidationSimpleError & {
   /**
    * @description Массив ошибок элементов валидируемого массива.
    * Индекс errorArray соответвует индексу валидируемого элемента массива
    */
   errorArray: Array<ValidationResult>;
 };
-
-/**
- * @description Array ошибок для массива
- */
-export class ValidationArrayError extends ValidationSimpleError<ValidationArrayErrorCause> {
-  constructor(
-    message: string,
-    data: ValidationErrorData<ValidationArrayErrorCause>,
-  ) {
-    super(message, data);
-    this.cause = data.cause;
-  }
-}

--- a/package/src/core/errors/ArrayError/createArrayError/createArrayError.test.ts
+++ b/package/src/core/errors/ArrayError/createArrayError/createArrayError.test.ts
@@ -1,4 +1,5 @@
 import { createSimpleError } from '../../SimpleError';
+import { createErrorCode } from '../../createErrorCode';
 
 import { createArrayError } from './createArrayError';
 
@@ -6,7 +7,10 @@ describe('createArrayError', () => {
   it('Подставляет в error.message текст от первой ошибки из массива', () => {
     const errorArray = [
       undefined,
-      createSimpleError({ message: 'name error', code: Symbol() }),
+      createSimpleError({
+        message: 'name error',
+        code: createErrorCode('name'),
+      }),
     ];
 
     const error = createArrayError(errorArray);
@@ -17,22 +21,28 @@ describe('createArrayError', () => {
   it('В error.code попадает код из первой ошибки map', () => {
     const errorArray = [
       undefined,
-      createSimpleError({ message: 'name error', code: Symbol() }),
+      createSimpleError({
+        message: 'name error',
+        code: createErrorCode('name'),
+      }),
     ];
 
     const error = createArrayError(errorArray);
 
-    expect(error.cause.code).toBe(errorArray[1]?.cause.code);
+    expect(error.code).toBe(errorArray[1]?.code);
   });
 
-  it('В error.cause.errorArray записывается array из аргумента', () => {
+  it('В error.errorArray записывается array из аргумента', () => {
     const errorArray = [
       undefined,
-      createSimpleError({ message: 'name error', code: Symbol() }),
+      createSimpleError({
+        message: 'name error',
+        code: createErrorCode('name'),
+      }),
     ];
 
     const error = createArrayError(errorArray);
 
-    expect(error.cause.errorArray).toEqual(errorArray);
+    expect(error.errorArray).toEqual(errorArray);
   });
 });

--- a/package/src/core/errors/ArrayError/createArrayError/createArrayError.ts
+++ b/package/src/core/errors/ArrayError/createArrayError/createArrayError.ts
@@ -1,19 +1,18 @@
-import { ValidationArrayError, ValidationArrayErrorCause } from '../ArrayError';
+import { ValidationArrayError } from '../ArrayError';
 import { ValidationSimpleError } from '../../SimpleError';
 
 /**
  * @description Создает array ошибок. Ошибка предназначена для результата валидации массива
  */
 export const createArrayError = (
-  errorArray: ValidationArrayErrorCause['errorArray'],
-) => {
+  errorArray: ValidationArrayError['errorArray'],
+): ValidationArrayError => {
   const firstErrorIndex = errorArray.findIndex((error) => Boolean(error));
   const firstError = errorArray[firstErrorIndex] as ValidationSimpleError;
 
-  return new ValidationArrayError(
-    `Ошибка в item[${firstErrorIndex}]: ${firstError.message}`,
-    {
-      cause: { errorArray, code: firstError.cause.code },
-    },
-  );
+  return {
+    message: `Ошибка в item[${firstErrorIndex}]: ${firstError.message}`,
+    code: firstError.code,
+    errorArray,
+  };
 };

--- a/package/src/core/errors/ErrorMap/ErrorMap.ts
+++ b/package/src/core/errors/ErrorMap/ErrorMap.ts
@@ -1,30 +1,9 @@
-import { ValidationErrorData, ValidationSimpleError } from '../SimpleError';
+import { ValidationSimpleError } from '../SimpleError';
 import { ValidationResult } from '../../types';
 
-/**
- * @description Map, которое содержит результат валидации свойств
- */
-export type ErrorMap = Record<string, ValidationResult>;
-
-/**
- * @description Доп. поля для ошибки в объекте
- */
-export type ValidationObjectErrorCause = {
+export type ValidationErrorMap = ValidationSimpleError & {
   /**
    * @description Map, которое содержит результат валидации свойств
    */
   errorMap: Record<string, ValidationResult>;
 };
-
-/**
- * @description Map ошибок для объекта
- */
-export class ValidationErrorMap extends ValidationSimpleError<ValidationObjectErrorCause> {
-  constructor(
-    message: string,
-    data: ValidationErrorData<ValidationObjectErrorCause>,
-  ) {
-    super(message, data);
-    this.cause = data.cause;
-  }
-}

--- a/package/src/core/errors/ErrorMap/createErrorMap/createErrorMap.test.ts
+++ b/package/src/core/errors/ErrorMap/createErrorMap/createErrorMap.test.ts
@@ -1,4 +1,5 @@
 import { createSimpleError } from '../../SimpleError';
+import { createErrorCode } from '../../createErrorCode';
 
 import { createErrorMap } from './createErrorMap';
 
@@ -6,8 +7,14 @@ describe('createErrorMap', () => {
   it('Подставляет в error.message текст от первой ошибки из map', () => {
     const errorMap = {
       age: undefined,
-      name: createSimpleError({ message: 'name error', code: Symbol() }),
-      surname: createSimpleError({ message: 'surname error', code: Symbol() }),
+      name: createSimpleError({
+        message: 'name error',
+        code: createErrorCode('name'),
+      }),
+      surname: createSimpleError({
+        message: 'surname error',
+        code: createErrorCode('surname'),
+      }),
     };
 
     const error = createErrorMap(errorMap);
@@ -17,23 +24,35 @@ describe('createErrorMap', () => {
 
   it('В error.code попадает код из первой ошибки map', () => {
     const errorMap = {
-      name: createSimpleError({ message: 'name error', code: Symbol() }),
-      surname: createSimpleError({ message: 'surname error', code: Symbol() }),
+      name: createSimpleError({
+        message: 'name error',
+        code: createErrorCode('name'),
+      }),
+      surname: createSimpleError({
+        message: 'surname error',
+        code: createErrorCode('surname'),
+      }),
     };
 
     const error = createErrorMap(errorMap);
 
-    expect(error.cause.code).toBe(errorMap.name.cause.code);
+    expect(error.code).toBe(errorMap.name.code);
   });
 
-  it('В error.cause.errorMap записывается объект из аргумента', () => {
+  it('В error.errorMap записывается объект из аргумента', () => {
     const errorMap = {
-      name: createSimpleError({ message: 'name error', code: Symbol() }),
-      surname: createSimpleError({ message: 'surname error', code: Symbol() }),
+      name: createSimpleError({
+        message: 'name error',
+        code: createErrorCode('name'),
+      }),
+      surname: createSimpleError({
+        message: 'surname error',
+        code: createErrorCode('surname'),
+      }),
     };
 
     const error = createErrorMap(errorMap);
 
-    expect(error.cause.errorMap).toEqual(errorMap);
+    expect(error.errorMap).toEqual(errorMap);
   });
 });

--- a/package/src/core/errors/ErrorMap/createErrorMap/createErrorMap.ts
+++ b/package/src/core/errors/ErrorMap/createErrorMap/createErrorMap.ts
@@ -1,20 +1,19 @@
-import { ValidationErrorMap, ValidationObjectErrorCause } from '../ErrorMap';
+import { ValidationErrorMap } from '../ErrorMap';
 import { ValidationSimpleError } from '../../SimpleError';
 
 /**
  * @description Создает map ошибок валидаций. Ошибка предназначена для генерации результата валидации объекта
  */
 export const createErrorMap = (
-  errorMap: ValidationObjectErrorCause['errorMap'],
-) => {
+  errorMap: ValidationErrorMap['errorMap'],
+): ValidationErrorMap => {
   const [firstErrorPath, firstError] = Object.entries(errorMap).find(
     ([, error]) => Boolean(error),
   ) as [string, ValidationSimpleError];
 
-  return new ValidationErrorMap(
-    `Ошибка в свойстве ${firstErrorPath}: ${firstError.message}`,
-    {
-      cause: { errorMap, code: firstError.cause.code },
-    },
-  );
+  return {
+    message: `Ошибка в свойстве ${firstErrorPath}: ${firstError.message}`,
+    code: firstError.code,
+    errorMap,
+  };
 };

--- a/package/src/core/errors/SimpleError/SimpleError.ts
+++ b/package/src/core/errors/SimpleError/SimpleError.ts
@@ -1,24 +1,12 @@
 import { ErrorCode } from '../types';
 
 /**
- * @description Причина ошибки валидации
- */
-export type ValidationErrorData<AddCause extends Record<string, unknown>> = {
-  cause: AddCause & {
-    code: ErrorCode;
-  };
-};
-
-/**
  * @description Простая ошибка правил валидации. Не имеет вложенных ошибок
  */
-export class ValidationSimpleError<
-  AddCause extends Record<string, unknown> = {},
-> extends Error {
-  cause: ValidationErrorData<AddCause>['cause'];
-
-  constructor(message: string, data: ValidationErrorData<AddCause>) {
-    super(message);
-    this.cause = data.cause;
-  }
-}
+export type ValidationSimpleError = {
+  message: string;
+  /**
+   * @description Уникальный код ошибки
+   */
+  code: ErrorCode;
+};

--- a/package/src/core/errors/SimpleError/createSimpleError/createSimpleError.ts
+++ b/package/src/core/errors/SimpleError/createSimpleError/createSimpleError.ts
@@ -4,5 +4,5 @@ import { ErrorInfo } from '../../types';
 /**
  * @description Создает простую ошибки валидации. Используется в обычных rules
  */
-export const createSimpleError = ({ message, code }: ErrorInfo) =>
-  new ValidationSimpleError(message, { cause: { code } });
+export const createSimpleError = (error: ErrorInfo): ValidationSimpleError =>
+  error;

--- a/package/src/core/errors/createErrorCode/createErrorCode.ts
+++ b/package/src/core/errors/createErrorCode/createErrorCode.ts
@@ -1,0 +1,11 @@
+import { ErrorCode } from '../types';
+
+/**
+ * @description Создает уникальный код ошибки по переданному name
+ * @param name - уникальное имя ошибки
+ * @example
+ * ```ts
+ *  const STRING_TYPE_ERROR_CODE = createErrorCode('string-type');
+ * ```
+ */
+export const createErrorCode = (name: string): ErrorCode => `revizor-${name}`;

--- a/package/src/core/errors/createErrorCode/index.ts
+++ b/package/src/core/errors/createErrorCode/index.ts
@@ -1,0 +1,1 @@
+export * from './createErrorCode';

--- a/package/src/core/errors/index.ts
+++ b/package/src/core/errors/index.ts
@@ -5,3 +5,5 @@ export * from './ArrayError';
 export * from './ErrorMap';
 
 export * from './types';
+
+export * from './createErrorCode';

--- a/package/src/core/errors/types.ts
+++ b/package/src/core/errors/types.ts
@@ -5,7 +5,7 @@ import { ValidationArrayError } from './ArrayError';
 /**
  * @description Уникальный код ошибки валидации
  */
-export type ErrorCode = Symbol;
+export type ErrorCode = string;
 
 /**
  * @description Информация, которая есть для каждой ошибки

--- a/package/src/core/guard/createGuard/createGuard.test.ts
+++ b/package/src/core/guard/createGuard/createGuard.test.ts
@@ -7,9 +7,10 @@ describe('createGuard', () => {
   it('Создает guard, который возвращает ошибку', () => {
     const errorCode = createErrorCode('error');
 
-    const guard = createGuard<string, string>((_, ctx) => {
-      return ctx.createError({ message: 'myerror', code: errorCode });
-    });
+    const guard = createGuard<string, string>(() => ({
+      message: 'myerror',
+      code: errorCode,
+    }));
 
     const error = guard('value');
 
@@ -54,9 +55,10 @@ describe('createGuard', () => {
   it('guard.define:isOptional=true: если required не вернул ошибку, то пропускает валидацию дальше', () => {
     const errorCode = createErrorCode('error');
 
-    const guard = createGuard<string, string>((_, ctx) =>
-      ctx.createError({ message: '', code: errorCode }),
-    );
+    const guard = createGuard<string, string>(() => ({
+      message: '',
+      code: errorCode,
+    }));
 
     const error = guard.define({ isOptional: true })('value');
 

--- a/package/src/core/guard/createGuard/createGuard.test.ts
+++ b/package/src/core/guard/createGuard/createGuard.test.ts
@@ -7,10 +7,9 @@ describe('createGuard', () => {
   it('Создает guard, который возвращает ошибку', () => {
     const errorCode = createErrorCode('error');
 
-    const guard = createGuard<string, string>(() => ({
-      message: 'myerror',
-      code: errorCode,
-    }));
+    const guard = createGuard<string, string>((_, ctx) => {
+      return ctx.createError({ message: 'myerror', code: errorCode });
+    });
 
     const error = guard('value');
 
@@ -55,10 +54,9 @@ describe('createGuard', () => {
   it('guard.define:isOptional=true: если required не вернул ошибку, то пропускает валидацию дальше', () => {
     const errorCode = createErrorCode('error');
 
-    const guard = createGuard<string, string>(() => ({
-      message: '',
-      code: errorCode,
-    }));
+    const guard = createGuard<string, string>((_, ctx) =>
+      ctx.createError({ message: '', code: errorCode }),
+    );
 
     const error = guard.define({ isOptional: true })('value');
 

--- a/package/src/core/guard/createGuard/createGuard.test.ts
+++ b/package/src/core/guard/createGuard/createGuard.test.ts
@@ -1,10 +1,11 @@
 import { REQUIRED_ERROR_INFO } from '../../rule';
+import { createErrorCode } from '../../errors';
 
 import { createGuard } from './createGuard';
 
 describe('createGuard', () => {
   it('Создает guard, который возвращает ошибку', () => {
-    const errorCode = Symbol();
+    const errorCode = createErrorCode('error');
 
     const guard = createGuard<string, string>((_, ctx) => {
       return ctx.createError({ message: 'myerror', code: errorCode });
@@ -13,7 +14,7 @@ describe('createGuard', () => {
     const error = guard('value');
 
     expect(error?.message).toBe('myerror');
-    expect(error?.cause.code).toBe(errorCode);
+    expect(error?.code).toBe(errorCode);
   });
 
   it('По-дефолту проверяет правило на required', () => {
@@ -21,7 +22,7 @@ describe('createGuard', () => {
 
     const error = guard(undefined);
 
-    expect(error?.cause.code).toBe(REQUIRED_ERROR_INFO.code);
+    expect(error?.code).toBe(REQUIRED_ERROR_INFO.code);
   });
 
   it('guard.define: создает копию guard', () => {
@@ -51,7 +52,7 @@ describe('createGuard', () => {
   });
 
   it('guard.define:isOptional=true: если required не вернул ошибку, то пропускает валидацию дальше', () => {
-    const errorCode = Symbol();
+    const errorCode = createErrorCode('error');
 
     const guard = createGuard<string, string>((_, ctx) =>
       ctx.createError({ message: '', code: errorCode }),
@@ -59,7 +60,7 @@ describe('createGuard', () => {
 
     const error = guard.define({ isOptional: true })('value');
 
-    expect(error?.cause.code).toBe(errorCode);
+    expect(error?.code).toBe(errorCode);
   });
 
   it('Создает новый контекст, если его не было', () => {

--- a/package/src/core/guard/createGuard/createGuard.ts
+++ b/package/src/core/guard/createGuard/createGuard.ts
@@ -99,7 +99,7 @@ export const createGuard = <
       // если включен isOptional режим и required упал с ошибкой, то необходимо проигнорировать ошибку
       if (
         defOptions?.isOptional &&
-        validationResult?.cause.code === REQUIRED_ERROR_INFO.code
+        validationResult?.code === REQUIRED_ERROR_INFO.code
       ) {
         return undefined;
       }

--- a/package/src/core/guard/createGuard/createGuard.ts
+++ b/package/src/core/guard/createGuard/createGuard.ts
@@ -64,7 +64,7 @@ type GuardExecutor<TValues, AddDefOptions extends Record<string, unknown>> = (
  * const string = <TValues>(...rules: CompositionalValidationRule<string, TValues>[]) =>
  *   createGuard<string, TValues>((value, ctx) => {
  *     if (typeof value !== 'string') {
- *       return ctx.createError({ code: Symbol(), message: 'Не строка' });
+ *       return { code: Symbol(), message: 'Не строка' };
  *     }
  *
  *     return compose<string, TValues>(...rules)(value, ctx);

--- a/package/src/core/guard/createGuard/createGuard.ts
+++ b/package/src/core/guard/createGuard/createGuard.ts
@@ -64,7 +64,7 @@ type GuardExecutor<TValues, AddDefOptions extends Record<string, unknown>> = (
  * const string = <TValues>(...rules: CompositionalValidationRule<string, TValues>[]) =>
  *   createGuard<string, TValues>((value, ctx) => {
  *     if (typeof value !== 'string') {
- *       return { code: Symbol(), message: 'Не строка' };
+ *       return ctx.createError({ code: Symbol(), message: 'Не строка' });
  *     }
  *
  *     return compose<string, TValues>(...rules)(value, ctx);

--- a/package/src/core/rule/createRule/createRule.test.ts
+++ b/package/src/core/rule/createRule/createRule.test.ts
@@ -1,12 +1,14 @@
 import { expect } from 'vitest';
 
+import { createErrorCode } from '../../errors';
+
 import { CommonRuleParams, createRule } from './createRule';
 
 describe('createRule', () => {
   it('Создает правило валидации, которое возвращает ошибку', () => {
     const rule = () =>
       createRule<string>((_, ctx) =>
-        ctx.createError({ code: Symbol(), message: 'error' }),
+        ctx.createError({ code: createErrorCode('test'), message: 'error' }),
       );
 
     const error = rule()('');
@@ -28,7 +30,8 @@ describe('createRule', () => {
   it('Params.exclude: пропускает исключения, если exclude возвращает true', () => {
     const rule = ({ exclude }: CommonRuleParams<string>) =>
       createRule<string>(
-        (_, ctx) => ctx.createError({ code: Symbol(), message: 'error' }),
+        (_, ctx) =>
+          ctx.createError({ code: createErrorCode('test'), message: 'error' }),
         { exclude },
       );
 

--- a/package/src/core/rule/createRule/createRule.test.ts
+++ b/package/src/core/rule/createRule/createRule.test.ts
@@ -7,10 +7,9 @@ import { CommonRuleParams, createRule } from './createRule';
 describe('createRule', () => {
   it('Создает правило валидации, которое возвращает ошибку', () => {
     const rule = () =>
-      createRule<string>(() => ({
-        code: createErrorCode('test'),
-        message: 'error',
-      }));
+      createRule<string>((_, ctx) =>
+        ctx.createError({ code: createErrorCode('test'), message: 'error' }),
+      );
 
     const error = rule()('');
 
@@ -31,7 +30,8 @@ describe('createRule', () => {
   it('Params.exclude: пропускает исключения, если exclude возвращает true', () => {
     const rule = ({ exclude }: CommonRuleParams<string>) =>
       createRule<string>(
-        () => ({ code: createErrorCode('test'), message: 'error' }),
+        (_, ctx) =>
+          ctx.createError({ code: createErrorCode('test'), message: 'error' }),
         { exclude },
       );
 

--- a/package/src/core/rule/createRule/createRule.test.ts
+++ b/package/src/core/rule/createRule/createRule.test.ts
@@ -7,9 +7,10 @@ import { CommonRuleParams, createRule } from './createRule';
 describe('createRule', () => {
   it('Создает правило валидации, которое возвращает ошибку', () => {
     const rule = () =>
-      createRule<string>((_, ctx) =>
-        ctx.createError({ code: createErrorCode('test'), message: 'error' }),
-      );
+      createRule<string>(() => ({
+        code: createErrorCode('test'),
+        message: 'error',
+      }));
 
     const error = rule()('');
 
@@ -30,8 +31,7 @@ describe('createRule', () => {
   it('Params.exclude: пропускает исключения, если exclude возвращает true', () => {
     const rule = ({ exclude }: CommonRuleParams<string>) =>
       createRule<string>(
-        (_, ctx) =>
-          ctx.createError({ code: createErrorCode('test'), message: 'error' }),
+        () => ({ code: createErrorCode('test'), message: 'error' }),
         { exclude },
       );
 

--- a/package/src/core/rule/createRule/createRule.ts
+++ b/package/src/core/rule/createRule/createRule.ts
@@ -29,7 +29,7 @@ type RuleExecutor<ValidationType extends ValidationTypes, TValues> = (
  * const inn = (params: CommonRuleParams<string> & { message?: string }) =>
  *   createRule<string>((value, ctx) => {
  *     if (!isInn(value)) {
- *       return { code: Symbol(), message: params?.message || 'Неверный ИНН' };
+ *       return ctx.createError({ code: Symbol(), message: params?.message || 'Неверный ИНН' });
  *     }
  *
  *     return undefined;

--- a/package/src/core/rule/createRule/createRule.ts
+++ b/package/src/core/rule/createRule/createRule.ts
@@ -29,7 +29,7 @@ type RuleExecutor<ValidationType extends ValidationTypes, TValues> = (
  * const inn = (params: CommonRuleParams<string> & { message?: string }) =>
  *   createRule<string>((value, ctx) => {
  *     if (!isInn(value)) {
- *       return ctx.createError({ code: Symbol(), message: params?.message || 'Неверный ИНН' });
+ *       return { code: Symbol(), message: params?.message || 'Неверный ИНН' };
  *     }
  *
  *     return undefined;

--- a/package/src/core/rule/required/constants.ts
+++ b/package/src/core/rule/required/constants.ts
@@ -1,6 +1,7 @@
 import { ErrorInfo } from '../../errors';
+import { createErrorCode } from '../../errors';
 
 export const REQUIRED_ERROR_INFO: ErrorInfo = {
-  code: Symbol('required'),
+  code: createErrorCode('required'),
   message: 'Обязательно',
 };

--- a/package/src/core/rule/required/required.test.ts
+++ b/package/src/core/rule/required/required.test.ts
@@ -29,7 +29,7 @@ describe('required', () => {
     (value) => {
       const error = required()(value);
 
-      expect(error?.cause.code).toBe(REQUIRED_ERROR_INFO.code);
+      expect(error?.code).toBe(REQUIRED_ERROR_INFO.code);
     },
   );
 

--- a/package/src/core/rule/required/required.ts
+++ b/package/src/core/rule/required/required.ts
@@ -15,11 +15,12 @@ export const required = ({
    */
   message?: string;
 } = {}) =>
-  createRule<unknown>((value) => {
-    const createRequiredError = () => ({
-      ...REQUIRED_ERROR_INFO,
-      message: message || REQUIRED_ERROR_INFO.message,
-    });
+  createRule<unknown>((value, ctx) => {
+    const createRequiredError = () =>
+      ctx.createError({
+        ...REQUIRED_ERROR_INFO,
+        message: message || REQUIRED_ERROR_INFO.message,
+      });
 
     if (value === null) {
       return createRequiredError();

--- a/package/src/core/rule/required/required.ts
+++ b/package/src/core/rule/required/required.ts
@@ -15,12 +15,11 @@ export const required = ({
    */
   message?: string;
 } = {}) =>
-  createRule<unknown>((value, ctx) => {
-    const createRequiredError = () =>
-      ctx.createError({
-        ...REQUIRED_ERROR_INFO,
-        message: message || REQUIRED_ERROR_INFO.message,
-      });
+  createRule<unknown>((value) => {
+    const createRequiredError = () => ({
+      ...REQUIRED_ERROR_INFO,
+      message: message || REQUIRED_ERROR_INFO.message,
+    });
 
     if (value === null) {
       return createRequiredError();

--- a/package/src/min/constants.ts
+++ b/package/src/min/constants.ts
@@ -1,9 +1,9 @@
-import { ErrorCode } from '../core';
+import { ErrorCode, createErrorCode } from '../core';
 
-export const STRING_MIN_ERROR_CODE: ErrorCode = Symbol('string-min');
+export const STRING_MIN_ERROR_CODE: ErrorCode = createErrorCode('string-min');
 
-export const NUMBER_MIN_ERROR_CODE: ErrorCode = Symbol('number-min');
+export const NUMBER_MIN_ERROR_CODE: ErrorCode = createErrorCode('number-min');
 
-export const DATE_MIN_ERROR_CODE: ErrorCode = Symbol('date-min');
+export const DATE_MIN_ERROR_CODE: ErrorCode = createErrorCode('date-min');
 
-export const ARRAY_MIN_ERROR_CODE: ErrorCode = Symbol('array-min');
+export const ARRAY_MIN_ERROR_CODE: ErrorCode = createErrorCode('array-min');

--- a/package/src/min/min.test.ts
+++ b/package/src/min/min.test.ts
@@ -31,7 +31,7 @@ describe('min', () => {
 
       const error = validate(value);
 
-      expect(error?.cause.code).toBe(STRING_MIN_ERROR_CODE);
+      expect(error?.code).toBe(STRING_MIN_ERROR_CODE);
     },
   );
 
@@ -55,7 +55,7 @@ describe('min', () => {
 
     const error = validate(value);
 
-    expect(error?.cause.code).toBe(NUMBER_MIN_ERROR_CODE);
+    expect(error?.code).toBe(NUMBER_MIN_ERROR_CODE);
   });
 
   it('params.getMessage: позволяет переопределить message', () => {
@@ -86,6 +86,6 @@ describe('min', () => {
 
     const error = validate(value);
 
-    expect(error?.cause.code).toBe(ARRAY_MIN_ERROR_CODE);
+    expect(error?.code).toBe(ARRAY_MIN_ERROR_CODE);
   });
 });

--- a/package/src/min/min.ts
+++ b/package/src/min/min.ts
@@ -46,25 +46,25 @@ export const min = <ValidationType extends MinValidationTypes>(
       const isError = value.trim().length < threshold;
 
       return isError
-        ? {
+        ? ctx.createError({
             code: STRING_MIN_ERROR_CODE,
             message: getMessage(`Мин. символов: ${threshold}`),
-          }
+          })
         : undefined;
     }
 
     if (Array.isArray(value) && value.length < threshold) {
-      return {
+      return ctx.createError({
         code: ARRAY_MIN_ERROR_CODE,
         message: getMessage(`Не больше: ${threshold}`),
-      };
+      });
     }
 
     if (typeof value === 'number' && value < threshold) {
-      return {
+      return ctx.createError({
         code: NUMBER_MIN_ERROR_CODE,
         message: getMessage(`Не больше: ${threshold}`),
-      };
+      });
     }
 
     return undefined;

--- a/package/src/min/min.ts
+++ b/package/src/min/min.ts
@@ -46,25 +46,25 @@ export const min = <ValidationType extends MinValidationTypes>(
       const isError = value.trim().length < threshold;
 
       return isError
-        ? ctx.createError({
+        ? {
             code: STRING_MIN_ERROR_CODE,
             message: getMessage(`Мин. символов: ${threshold}`),
-          })
+          }
         : undefined;
     }
 
     if (Array.isArray(value) && value.length < threshold) {
-      return ctx.createError({
+      return {
         code: ARRAY_MIN_ERROR_CODE,
         message: getMessage(`Не больше: ${threshold}`),
-      });
+      };
     }
 
     if (typeof value === 'number' && value < threshold) {
-      return ctx.createError({
+      return {
         code: NUMBER_MIN_ERROR_CODE,
         message: getMessage(`Не больше: ${threshold}`),
-      });
+      };
     }
 
     return undefined;

--- a/package/src/object/constants.ts
+++ b/package/src/object/constants.ts
@@ -1,6 +1,6 @@
-import { ErrorInfo } from '../core';
+import { ErrorInfo, createErrorCode } from '../core';
 
 export const OBJECT_TYPE_ERROR_INFO: ErrorInfo = {
-  code: Symbol('object'),
+  code: createErrorCode('object'),
   message: 'Не является объектом',
 };

--- a/package/src/object/isEmptyErrors/isEmptyErrors.ts
+++ b/package/src/object/isEmptyErrors/isEmptyErrors.ts
@@ -1,7 +1,7 @@
-import { ErrorMap } from '../../core';
+import { ValidationErrorMap } from '../../core';
 
 /**
  * @description Проверяет есть ли errorMap ошибки
  */
-export const isEmptyErrors = (errorMap: ErrorMap) =>
+export const isEmptyErrors = (errorMap: ValidationErrorMap['errorMap']) =>
   Object.values(errorMap).every((error) => error === undefined);

--- a/package/src/object/object.test.ts
+++ b/package/src/object/object.test.ts
@@ -89,11 +89,10 @@ describe('object', () => {
 
   it('Поддерживает кастомные валидации для полей объекта', () => {
     const validate = object<{ name: string }>({
-      name: (_, ctx) =>
-        ctx.createError({
-          message: 'name error',
-          code: createErrorCode('error'),
-        }),
+      name: () => ({
+        message: 'name error',
+        code: createErrorCode('error'),
+      }),
     });
 
     const error = validate({}) as ValidationErrorMap;

--- a/package/src/object/object.test.ts
+++ b/package/src/object/object.test.ts
@@ -89,10 +89,11 @@ describe('object', () => {
 
   it('Поддерживает кастомные валидации для полей объекта', () => {
     const validate = object<{ name: string }>({
-      name: () => ({
-        message: 'name error',
-        code: createErrorCode('error'),
-      }),
+      name: (_, ctx) =>
+        ctx.createError({
+          message: 'name error',
+          code: createErrorCode('error'),
+        }),
     });
 
     const error = validate({}) as ValidationErrorMap;

--- a/package/src/object/object.test.ts
+++ b/package/src/object/object.test.ts
@@ -1,6 +1,7 @@
 import {
   REQUIRED_ERROR_INFO,
   ValidationErrorMap,
+  createErrorCode,
   createErrorMap,
   createSimpleError,
 } from '../core';
@@ -21,7 +22,7 @@ describe('object', () => {
 
       const result = validate(value);
 
-      expect(result?.cause.code).toBe(OBJECT_TYPE_ERROR_INFO.code);
+      expect(result?.code).toBe(OBJECT_TYPE_ERROR_INFO.code);
     },
   );
 
@@ -32,7 +33,7 @@ describe('object', () => {
 
       const result = validate(value);
 
-      expect(result?.cause.code).toBe(OBJECT_TYPE_ERROR_INFO.code);
+      expect(result?.code).toBe(OBJECT_TYPE_ERROR_INFO.code);
     },
   );
 
@@ -89,11 +90,14 @@ describe('object', () => {
   it('Поддерживает кастомные валидации для полей объекта', () => {
     const validate = object<{ name: string }>({
       name: (_, ctx) =>
-        ctx.createError({ message: 'name error', code: Symbol() }),
+        ctx.createError({
+          message: 'name error',
+          code: createErrorCode('error'),
+        }),
     });
 
     const error = validate({}) as ValidationErrorMap;
 
-    expect(error.cause.errorMap.name?.message).toBe('name error');
+    expect(error.errorMap.name?.message).toBe('name error');
   });
 });

--- a/package/src/object/object.ts
+++ b/package/src/object/object.ts
@@ -63,9 +63,7 @@ type Schema<TValue extends Record<string, unknown>, TValues> = Record<
  *   name: string(min(2)),
  *   age: optional(number()),
  *   info: object<Values['info']>({ surname: string(min(2)) }),
- *   customField: (value, ctx) => {
- *     return ctx.createError({ message: 'error', code: Symbol() })
- *   }
+ *   customField: (value, ctx) => ({ message: 'error', code: Symbol() }),
  * });
  * ```
  */
@@ -78,10 +76,10 @@ export const object = <
   createGuard<Value, TValues, AdditionalDefOptions>(
     (value, ctx, { typeErrorMessage, isPartial }) => {
       if (!isPlainObject(value)) {
-        return ctx.createError({
+        return {
           ...OBJECT_TYPE_ERROR_INFO,
           message: typeErrorMessage || OBJECT_TYPE_ERROR_INFO.message,
-        });
+        };
       }
 
       const generateErrorMap = () => {

--- a/package/src/object/object.ts
+++ b/package/src/object/object.ts
@@ -2,9 +2,9 @@ import isPlainObject from 'is-plain-obj';
 
 import {
   CompositionalValidationRule,
-  ErrorMap,
   Guard,
   ValidationContext,
+  ValidationErrorMap,
   createErrorMap,
   createGuard,
 } from '../core';
@@ -88,18 +88,21 @@ export const object = <
         const schemaEntries = Object.entries<SchemaValue<TValues>>(schema);
         const isOptional = ctx.global.overrides.objectIsPartial || isPartial;
 
-        return schemaEntries.reduce<ErrorMap>((errorMap, [key, rule]) => {
-          const isGuard = 'define' in rule;
+        return schemaEntries.reduce<ValidationErrorMap['errorMap']>(
+          (errorMap, [key, rule]) => {
+            const isGuard = 'define' in rule;
 
-          const callRule =
-            isGuard && isOptional
-              ? optional(rule as Guard<unknown, TValues>)
-              : rule;
+            const callRule =
+              isGuard && isOptional
+                ? optional(rule as Guard<unknown, TValues>)
+                : rule;
 
-          errorMap[key] = callRule(value[key], ctx);
+            errorMap[key] = callRule(value[key], ctx);
 
-          return errorMap;
-        }, {});
+            return errorMap;
+          },
+          {},
+        );
       };
 
       const errorMap = generateErrorMap();

--- a/package/src/object/object.ts
+++ b/package/src/object/object.ts
@@ -63,7 +63,9 @@ type Schema<TValue extends Record<string, unknown>, TValues> = Record<
  *   name: string(min(2)),
  *   age: optional(number()),
  *   info: object<Values['info']>({ surname: string(min(2)) }),
- *   customField: (value, ctx) => ({ message: 'error', code: Symbol() }),
+ *   customField: (value, ctx) => {
+ *     return ctx.createError({ message: 'error', code: Symbol() })
+ *   }
  * });
  * ```
  */
@@ -76,10 +78,10 @@ export const object = <
   createGuard<Value, TValues, AdditionalDefOptions>(
     (value, ctx, { typeErrorMessage, isPartial }) => {
       if (!isPlainObject(value)) {
-        return {
+        return ctx.createError({
           ...OBJECT_TYPE_ERROR_INFO,
           message: typeErrorMessage || OBJECT_TYPE_ERROR_INFO.message,
-        };
+        });
       }
 
       const generateErrorMap = () => {

--- a/package/src/or/or.test.ts
+++ b/package/src/or/or.test.ts
@@ -18,6 +18,6 @@ describe('or', () => {
 
     const error = validate(new Date());
 
-    expect(error?.cause.code).toBe(ARRAY_TYPE_ERROR_INFO.code);
+    expect(error?.code).toBe(ARRAY_TYPE_ERROR_INFO.code);
   });
 });

--- a/package/src/string/constants.ts
+++ b/package/src/string/constants.ts
@@ -1,6 +1,6 @@
-import { ErrorInfo } from '../core';
+import { ErrorInfo, createErrorCode } from '../core';
 
 export const STRING_TYPE_ERROR_INFO: ErrorInfo = {
-  code: Symbol('string'),
+  code: createErrorCode('string'),
   message: 'Не является строкой',
 };

--- a/package/src/string/string.test.ts
+++ b/package/src/string/string.test.ts
@@ -24,7 +24,7 @@ describe('string', () => {
   it('Вызывает переданные rules', () => {
     const validate = string(
       () => undefined,
-      () => ({ message: 'stringerror', code: 'error' }),
+      (_, ctx) => ctx.createError({ message: 'stringerror', code: 'error' }),
     );
 
     const result = validate('string');

--- a/package/src/string/string.test.ts
+++ b/package/src/string/string.test.ts
@@ -9,7 +9,7 @@ describe('string', () => {
 
       const result = validate(value);
 
-      expect(result?.cause.code).toBe(STRING_TYPE_ERROR_INFO.code);
+      expect(result?.code).toBe(STRING_TYPE_ERROR_INFO.code);
     },
   );
 
@@ -24,7 +24,7 @@ describe('string', () => {
   it('Вызывает переданные rules', () => {
     const validate = string(
       () => undefined,
-      (_, ctx) => ctx.createError({ message: 'stringerror', code: Symbol() }),
+      (_, ctx) => ctx.createError({ message: 'stringerror', code: 'error' }),
     );
 
     const result = validate('string');

--- a/package/src/string/string.test.ts
+++ b/package/src/string/string.test.ts
@@ -24,7 +24,7 @@ describe('string', () => {
   it('Вызывает переданные rules', () => {
     const validate = string(
       () => undefined,
-      (_, ctx) => ctx.createError({ message: 'stringerror', code: 'error' }),
+      () => ({ message: 'stringerror', code: 'error' }),
     );
 
     const result = validate('string');

--- a/package/src/string/string.ts
+++ b/package/src/string/string.ts
@@ -7,10 +7,10 @@ export const string = <TValues>(
 ) =>
   createGuard<string, TValues>((value, ctx, { typeErrorMessage }) => {
     if (typeof value !== 'string') {
-      return {
+      return ctx.createError({
         ...STRING_TYPE_ERROR_INFO,
         message: typeErrorMessage || STRING_TYPE_ERROR_INFO.message,
-      };
+      });
     }
 
     return compose<string, TValues>(...rules)(value, ctx);

--- a/package/src/string/string.ts
+++ b/package/src/string/string.ts
@@ -7,10 +7,10 @@ export const string = <TValues>(
 ) =>
   createGuard<string, TValues>((value, ctx, { typeErrorMessage }) => {
     if (typeof value !== 'string') {
-      return ctx.createError({
+      return {
         ...STRING_TYPE_ERROR_INFO,
         message: typeErrorMessage || STRING_TYPE_ERROR_INFO.message,
-      });
+      };
     }
 
     return compose<string, TValues>(...rules)(value, ctx);


### PR DESCRIPTION
- Error классы заменены на простые объекта для того, чтобы: упростить определение кастомных правил, уменьшить количество операций при форматировании ошибок в формат, необходимый для отображения или использования в других библиотеках (react-hook-form)
- Из контекста удален метод createError. Теперь достаточно просто вернуть объект из правила
- Изменен тип кодов ошибок с Symbol на string для возможности сериализации ошибок и использования их в других библиотеках (react-hook-form)